### PR TITLE
Added lazy loading by wrapping the pyenv function

### DIFF
--- a/zsh-pyenv.plugin.zsh
+++ b/zsh-pyenv.plugin.zsh
@@ -16,15 +16,20 @@ _zsh_pyenv_load() {
     # export PATH
     export PATH="$PYENV_HOME/bin:$PATH"
 
-    eval "$(pyenv init -)"
-    eval "$(pyenv virtualenv-init -)"
+    eval "$(command pyenv init -)"
+    eval "$(command pyenv virtualenv-init -)"
+    
+    # call the actual pyenv function
+    pyenv "$@"
 }
 
-# install pyenv if it isnt already installed
-[[ ! -f "$PYENV_HOME/libexec/pyenv" ]] && _zsh_pyenv_install
 
-# load pyenv if it is installed
-if [[ -f "$PYENV_HOME/libexec/pyenv" ]]; then
-    _zsh_pyenv_load
-fi
-
+# Wrap the pyenv function so that pyenv is loaded lazily
+pyenv() {
+	# install pyenv if it isnt already installed
+	[[ ! -f "$PYENV_HOME/libexec/pyenv" ]] && _zsh_pyenv_install
+	# load pyenv if it is installed
+	if [[ -f "$PYENV_HOME/libexec/pyenv" ]]; then
+	    _zsh_pyenv_load
+	fi
+}


### PR DESCRIPTION
I wanted to make pyenv load lazily. 

In order to do that, I wrapped the original code in a function with the pyenv name so that pyenv is only activated when the user first calls pyenv.  After the first call, the user can invoke pyenv as normal.