### PR TITLE
include pyenv bin, so pyenv can be found when present

### DIFF
--- a/zsh-pyenv.plugin.zsh
+++ b/zsh-pyenv.plugin.zsh
@@ -2,6 +2,9 @@ GITHUB="https://github.com"
 
 [[ -z "$PYENV_HOME" ]] && export PYENV_HOME="$HOME/.pyenv"
 
+# export PATH
+export PATH="$PYENV_HOME/bin:$PATH"
+
 _zsh_pyenv_install() {
     echo "Installing pyenv..."
     git clone "${GITHUB}/pyenv/pyenv.git"            "${PYENV_HOME}"
@@ -13,9 +16,6 @@ _zsh_pyenv_install() {
 }
 
 _zsh_pyenv_load() {
-    # export PATH
-    export PATH="$PYENV_HOME/bin:$PATH"
-
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
 }


### PR DESCRIPTION
The last commit checks if pyenv is installed. This always fails since the pyenv bin folder gets included after the check.